### PR TITLE
Ability to query options ERC-1155 tokens

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -12,7 +12,7 @@ type Option @entity {
   underlyingAmount: BigInt
   settlementSeed: BigInt
   exerciseAmount: BigInt
-  writer: Bytes # address
+  creator: Bytes # address
   claimId: BigInt
   amount: BigInt
   exercisee: Bytes
@@ -52,6 +52,7 @@ TODO(Token should contain a type enumeration reflecting which type of token it i
 
 type Token @entity {
   id: ID!
+  type: Int
   registry: TokenRegistry!
   identifier: BigInt!
   URI: String

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,9 +1,3 @@
-type ExampleEntity @entity {
-  id: ID!
-  count: BigInt!
-  owner: Bytes! # address
-  operator: Bytes! # address
-}
 
 type User @entity {
   id: ID!
@@ -37,9 +31,6 @@ type Claim @entity {
   underlyingAmount: BigInt
 }
 
-
-
-
 type Account @entity {
   id: ID!
   balances: [Balance!]! @derivedFrom(field: "account")
@@ -54,6 +45,10 @@ type TokenRegistry @entity {
   id: ID!
   tokens: [Token!]! @derivedFrom(field: "registry")
 }
+
+"""
+TODO(Token should contain a type enumeration reflecting which type of token it is in the protocol for query)
+"""
 
 type Token @entity {
   id: ID!

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -1,7 +1,5 @@
 import { BigInt, ethereum } from "@graphprotocol/graph-ts"
 import {
-  OptionsSettlementEngine,
-  ApprovalForAll,
   ClaimRedeemed,
   ExerciseAssigned,
   FeeAccrued,
@@ -12,13 +10,11 @@ import {
   URI
 } from "../generated/OptionsSettlementEngine/OptionsSettlementEngine"
 
-import { Account, Balance, Claim, ExampleEntity, Option, Token, TokenRegistry, Transaction, Transfer } from "../generated/schema"
+import { Account, Balance, Claim, Option, Token, TokenRegistry, Transaction, Transfer } from "../generated/schema"
 
 import {
   TransferBatch as TransferBatchEvent,
   TransferSingle as TransferSingleEvent,
-  URI as URIEvent,
-  ApprovalForAll as ApprovalForAllEvent,
 } from '../generated/OptionsSettlementEngine/IERC1155';
 
 import { IERC1155MetadataURI } from '../generated/OptionsSettlementEngine/IERC1155MetadataURI';
@@ -103,63 +99,6 @@ function registerTransfer(
   ev.save();
 }
 
-
-
-export function handleApprovalForAll(event: ApprovalForAll): void {
-  // Entities can be loaded from the store using a string ID; this ID
-  // needs to be unique across all entities of the same type
-  let entity = ExampleEntity.load(event.transaction.from.toHex())
-
-  // Entities only exist after they have been saved to the store;
-  // `null` checks allow to create entities on demand
-  if (!entity) {
-    entity = new ExampleEntity(event.transaction.from.toHex())
-
-    // Entity fields can be set using simple assignments
-    entity.count = BigInt.fromI32(0)
-  }
-
-  // BigInt and BigDecimal math are supported
-  entity.count = entity.count.plus(BigInt.fromI32(1))
-
-  // Entity fields can be set based on event parameters
-  entity.owner = event.params.owner
-  entity.operator = event.params.operator
-
-  // Entities can be written to the store with `.save()`
-  entity.save()
-
-  // Note: If a handler doesn't require existing field values, it is faster
-  // _not_ to load the entity from the store. Instead, create it fresh with
-  // `new Entity(...)`, set the fields that should be updated and save the
-  // entity back to the store. Fields that were not set or unset remain
-  // unchanged, allowing for partial updates to be applied.
-
-  // It is also possible to access smart contracts from mappings. For
-  // example, the contract that has emitted the event can be connected to
-  // with:
-  //
-  // let contract = Contract.bind(event.address)
-  //
-  // The following functions can then be called on this contract to access
-  // state variables and other data:
-  //
-  // - contract.balanceOf(...)
-  // - contract.balanceOfBatch(...)
-  // - contract.claim(...)
-  // - contract.feeBalance(...)
-  // - contract.feeBps(...)
-  // - contract.feeTo(...)
-  // - contract.hashToOptionToken(...)
-  // - contract.isApprovedForAll(...)
-  // - contract.newChain(...)
-  // - contract.option(...)
-  // - contract.supportsInterface(...)
-  // - contract.tokenType(...)
-  // - contract.underlying(...)
-  // - contract.uri(...)
-  // - contract.write(...)
-}
 
 export function handleClaimRedeemed(event: ClaimRedeemed): void {
   let claim = Claim.load(event.params.claimId.toString());
@@ -246,9 +185,6 @@ export function handleOptionsWritten(event: OptionsWritten): void {
 
       option.save();
 }
-
-
-
 
 
 export function handleTransferBatch(event: TransferBatchEvent): void {

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -13,7 +13,6 @@ dataSources:
       apiVersion: 0.0.5
       language: wasm/assemblyscript
       entities:
-        - ApprovalForAll
         - ClaimRedeemed
         - ExerciseAssigned
         - FeeAccrued
@@ -32,8 +31,6 @@ dataSources:
         - name: IERC1155MetadataURI
           file: ./abis/IERC1155MetadataURI.json
       eventHandlers:
-        - event: ApprovalForAll(indexed address,indexed address,bool)
-          handler: handleApprovalForAll
         - event: ClaimRedeemed(indexed uint256,indexed uint256,indexed address,address,address,uint96,uint96)
           handler: handleClaimRedeemed
         - event: ExerciseAssigned(indexed uint256,indexed uint256,uint112)


### PR DESCRIPTION
This PR adds a type field to the ERC-1155 tokens created by the protocol in the subgraph. This type enum/int can be used to query for all tokens of type option produced by the prococol in a given user's wallet.