### PR TITLE
Update subgraph to use current ABI

### DIFF
--- a/abis/OptionSettlementEngine.json
+++ b/abis/OptionSettlementEngine.json
@@ -1,17 +1,63 @@
 [
   {
     "inputs": [
+      { "internalType": "address", "name": "_feeTo", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "_tokenURIGenerator",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
       { "internalType": "address", "name": "accessor", "type": "address" },
       { "internalType": "address", "name": "permissioned", "type": "address" }
     ],
     "name": "AccessControlViolation",
     "type": "error"
   },
-  { "inputs": [], "name": "AlreadyClaimed", "type": "error" },
-  { "inputs": [], "name": "BalanceTooLow", "type": "error" },
-  { "inputs": [], "name": "ClaimTooSoon", "type": "error" },
-  { "inputs": [], "name": "ExerciseTooEarly", "type": "error" },
-  { "inputs": [], "name": "ExerciseWindowTooShort", "type": "error" },
+  { "inputs": [], "name": "AmountWrittenCannotBeZero", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "claimId", "type": "uint256" }
+    ],
+    "name": "CallerDoesNotOwnClaimId",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "optionId", "type": "uint256" },
+      { "internalType": "uint112", "name": "amount", "type": "uint112" }
+    ],
+    "name": "CallerHoldsInsufficientOptions",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "claimId", "type": "uint256" },
+      { "internalType": "uint40", "name": "expiry", "type": "uint40" }
+    ],
+    "name": "ClaimTooSoon",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "optionId", "type": "uint256" },
+      { "internalType": "uint40", "name": "exercise", "type": "uint40" }
+    ],
+    "name": "ExerciseTooEarly",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint40", "name": "exercise", "type": "uint40" }
+    ],
+    "name": "ExerciseWindowTooShort",
+    "type": "error"
+  },
   {
     "inputs": [
       { "internalType": "uint256", "name": "optionId", "type": "uint256" },
@@ -20,7 +66,20 @@
     "name": "ExpiredOption",
     "type": "error"
   },
-  { "inputs": [], "name": "ExpiryTooSoon", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "uint40", "name": "expiry", "type": "uint40" }
+    ],
+    "name": "ExpiryWindowTooShort",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "input", "type": "address" }
+    ],
+    "name": "InvalidAddress",
+    "type": "error"
+  },
   {
     "inputs": [
       { "internalType": "address", "name": "asset1", "type": "address" },
@@ -43,12 +102,11 @@
     "name": "InvalidOption",
     "type": "error"
   },
-  { "inputs": [], "name": "NoClaims", "type": "error" },
   {
     "inputs": [
-      { "internalType": "bytes32", "name": "hash", "type": "bytes32" }
+      { "internalType": "uint256", "name": "optionId", "type": "uint256" }
     ],
-    "name": "OptionsChainExists",
+    "name": "OptionsTypeExists",
     "type": "error"
   },
   {
@@ -106,27 +164,15 @@
       },
       {
         "indexed": false,
-        "internalType": "address",
-        "name": "exerciseAsset",
-        "type": "address"
+        "internalType": "uint256",
+        "name": "exerciseAmountRedeemed",
+        "type": "uint256"
       },
       {
         "indexed": false,
-        "internalType": "address",
-        "name": "underlyingAsset",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint96",
-        "name": "exerciseAmount",
-        "type": "uint96"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint96",
-        "name": "underlyingAmount",
-        "type": "uint96"
+        "internalType": "uint256",
+        "name": "underlyingAmountRedeemed",
+        "type": "uint256"
       }
     ],
     "name": "ClaimRedeemed",
@@ -138,28 +184,9 @@
       {
         "indexed": true,
         "internalType": "uint256",
-        "name": "claimId",
-        "type": "uint256"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
         "name": "optionId",
         "type": "uint256"
       },
-      {
-        "indexed": false,
-        "internalType": "uint112",
-        "name": "amountAssigned",
-        "type": "uint112"
-      }
-    ],
-    "name": "ExerciseAssigned",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
       {
         "indexed": true,
         "internalType": "address",
@@ -169,7 +196,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "payor",
+        "name": "payer",
         "type": "address"
       },
       {
@@ -188,7 +215,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "token",
+        "name": "asset",
         "type": "address"
       },
       {
@@ -211,7 +238,39 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "address",
+        "name": "feeTo",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "FeeSwitchUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
+        "internalType": "address",
+        "name": "newFeeTo",
+        "type": "address"
+      }
+    ],
+    "name": "FeeToUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "internalType": "uint256",
         "name": "optionId",
         "type": "uint256"
@@ -247,13 +306,13 @@
         "type": "uint40"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "uint40",
         "name": "expiryTimestamp",
         "type": "uint40"
       }
     ],
-    "name": "NewChain",
+    "name": "NewOptionType",
     "type": "event"
   },
   {
@@ -268,7 +327,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "exercisee",
+        "name": "exerciser",
         "type": "address"
       },
       {
@@ -297,7 +356,7 @@
         "type": "address"
       },
       {
-        "indexed": false,
+        "indexed": true,
         "internalType": "uint256",
         "name": "claimId",
         "type": "uint256"
@@ -310,6 +369,19 @@
       }
     ],
     "name": "OptionsWritten",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newTokenURIGenerator",
+        "type": "address"
+      }
+    ],
+    "name": "TokenURIGeneratorUpdated",
     "type": "event"
   },
   {
@@ -429,24 +501,24 @@
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+      { "internalType": "uint256", "name": "claimId", "type": "uint256" }
     ],
     "name": "claim",
     "outputs": [
       {
         "components": [
-          { "internalType": "uint256", "name": "option", "type": "uint256" },
           {
-            "internalType": "uint112",
+            "internalType": "uint256",
             "name": "amountWritten",
-            "type": "uint112"
+            "type": "uint256"
           },
           {
-            "internalType": "uint112",
+            "internalType": "uint256",
             "name": "amountExercised",
-            "type": "uint112"
+            "type": "uint256"
           },
-          { "internalType": "bool", "name": "claimed", "type": "bool" }
+          { "internalType": "uint256", "name": "optionId", "type": "uint256" },
+          { "internalType": "bool", "name": "unredeemed", "type": "bool" }
         ],
         "internalType": "struct IOptionSettlementEngine.Claim",
         "name": "claimInfo",
@@ -488,9 +560,9 @@
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "name": "hashToOptionToken",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "inputs": [],
+    "name": "feesEnabled",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
     "stateMutability": "view",
     "type": "function"
   },
@@ -507,49 +579,25 @@
   {
     "inputs": [
       {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "underlyingAsset",
-            "type": "address"
-          },
-          {
-            "internalType": "uint40",
-            "name": "exerciseTimestamp",
-            "type": "uint40"
-          },
-          {
-            "internalType": "uint40",
-            "name": "expiryTimestamp",
-            "type": "uint40"
-          },
-          {
-            "internalType": "address",
-            "name": "exerciseAsset",
-            "type": "address"
-          },
-          {
-            "internalType": "uint96",
-            "name": "underlyingAmount",
-            "type": "uint96"
-          },
-          {
-            "internalType": "uint160",
-            "name": "settlementSeed",
-            "type": "uint160"
-          },
-          {
-            "internalType": "uint96",
-            "name": "exerciseAmount",
-            "type": "uint96"
-          }
-        ],
-        "internalType": "struct IOptionSettlementEngine.Option",
-        "name": "optionInfo",
-        "type": "tuple"
-      }
+        "internalType": "address",
+        "name": "underlyingAsset",
+        "type": "address"
+      },
+      {
+        "internalType": "uint96",
+        "name": "underlyingAmount",
+        "type": "uint96"
+      },
+      { "internalType": "address", "name": "exerciseAsset", "type": "address" },
+      { "internalType": "uint96", "name": "exerciseAmount", "type": "uint96" },
+      {
+        "internalType": "uint40",
+        "name": "exerciseTimestamp",
+        "type": "uint40"
+      },
+      { "internalType": "uint40", "name": "expiryTimestamp", "type": "uint40" }
     ],
-    "name": "newChain",
+    "name": "newOptionType",
     "outputs": [
       { "internalType": "uint256", "name": "optionId", "type": "uint256" }
     ],
@@ -570,6 +618,21 @@
             "type": "address"
           },
           {
+            "internalType": "uint96",
+            "name": "underlyingAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "address",
+            "name": "exerciseAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "uint96",
+            "name": "exerciseAmount",
+            "type": "uint96"
+          },
+          {
             "internalType": "uint40",
             "name": "exerciseTimestamp",
             "type": "uint40"
@@ -580,25 +643,11 @@
             "type": "uint40"
           },
           {
-            "internalType": "address",
-            "name": "exerciseAsset",
-            "type": "address"
-          },
-          {
-            "internalType": "uint96",
-            "name": "underlyingAmount",
-            "type": "uint96"
-          },
-          {
             "internalType": "uint160",
             "name": "settlementSeed",
             "type": "uint160"
           },
-          {
-            "internalType": "uint96",
-            "name": "exerciseAmount",
-            "type": "uint96"
-          }
+          { "internalType": "uint96", "name": "nextClaimKey", "type": "uint96" }
         ],
         "internalType": "struct IOptionSettlementEngine.Option",
         "name": "optionInfo",
@@ -663,6 +712,26 @@
     "type": "function"
   },
   {
+    "inputs": [{ "internalType": "bool", "name": "enabled", "type": "bool" }],
+    "name": "setFeesEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newTokenURIGenerator",
+        "type": "address"
+      }
+    ],
+    "name": "setTokenURIGenerator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       { "internalType": "bytes4", "name": "interfaceId", "type": "bytes4" }
     ],
@@ -681,13 +750,28 @@
     "type": "function"
   },
   {
-    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "inputs": [
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
     "name": "tokenType",
     "outputs": [
       {
-        "internalType": "enum IOptionSettlementEngine.Type",
-        "name": "",
+        "internalType": "enum IOptionSettlementEngine.TokenType",
+        "name": "typeOfToken",
         "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tokenURIGenerator",
+    "outputs": [
+      {
+        "internalType": "contract ITokenURIGenerator",
+        "name": "",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -723,7 +807,7 @@
           }
         ],
         "internalType": "struct IOptionSettlementEngine.Underlying",
-        "name": "underlyingPositions",
+        "name": "underlyingPosition",
         "type": "tuple"
       }
     ],
@@ -741,13 +825,11 @@
   },
   {
     "inputs": [
-      { "internalType": "uint256", "name": "optionId", "type": "uint256" },
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" },
       { "internalType": "uint112", "name": "amount", "type": "uint112" }
     ],
     "name": "write",
-    "outputs": [
-      { "internalType": "uint256", "name": "claimId", "type": "uint256" }
-    ],
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
     "stateMutability": "nonpayable",
     "type": "function"
   }

--- a/abis/OptionSettlementEngine.json
+++ b/abis/OptionSettlementEngine.json
@@ -659,6 +659,43 @@
   },
   {
     "inputs": [
+      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
+    ],
+    "name": "position",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "underlyingAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "int256",
+            "name": "underlyingAmount",
+            "type": "int256"
+          },
+          {
+            "internalType": "address",
+            "name": "exerciseAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "int256",
+            "name": "exerciseAmount",
+            "type": "int256"
+          }
+        ],
+        "internalType": "struct IOptionSettlementEngine.Position",
+        "name": "positionInfo",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
       { "internalType": "uint256", "name": "claimId", "type": "uint256" }
     ],
     "name": "redeem",
@@ -772,43 +809,6 @@
         "internalType": "contract ITokenURIGenerator",
         "name": "",
         "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "uint256", "name": "tokenId", "type": "uint256" }
-    ],
-    "name": "underlying",
-    "outputs": [
-      {
-        "components": [
-          {
-            "internalType": "address",
-            "name": "underlyingAsset",
-            "type": "address"
-          },
-          {
-            "internalType": "int256",
-            "name": "underlyingPosition",
-            "type": "int256"
-          },
-          {
-            "internalType": "address",
-            "name": "exerciseAsset",
-            "type": "address"
-          },
-          {
-            "internalType": "int256",
-            "name": "exercisePosition",
-            "type": "int256"
-          }
-        ],
-        "internalType": "struct IOptionSettlementEngine.Underlying",
-        "name": "underlyingPosition",
-        "type": "tuple"
       }
     ],
     "stateMutability": "view",

--- a/abis/TokenURIGenerator.json
+++ b/abis/TokenURIGenerator.json
@@ -1,0 +1,242 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "underlyingAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "exerciseAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "exerciseSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "uint40",
+            "name": "exerciseTimestamp",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint40",
+            "name": "expiryTimestamp",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint96",
+            "name": "underlyingAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint96",
+            "name": "exerciseAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "enum IOptionSettlementEngine.TokenType",
+            "name": "tokenType",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ITokenURIGenerator.TokenURIParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "constructTokenURI",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "underlyingAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "exerciseAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "exerciseSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "uint40",
+            "name": "exerciseTimestamp",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint40",
+            "name": "expiryTimestamp",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint96",
+            "name": "underlyingAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint96",
+            "name": "exerciseAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "enum IOptionSettlementEngine.TokenType",
+            "name": "tokenType",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ITokenURIGenerator.TokenURIParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "generateDescription",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "underlyingAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "exerciseAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "exerciseSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "uint40",
+            "name": "exerciseTimestamp",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint40",
+            "name": "expiryTimestamp",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint96",
+            "name": "underlyingAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint96",
+            "name": "exerciseAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "enum IOptionSettlementEngine.TokenType",
+            "name": "tokenType",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ITokenURIGenerator.TokenURIParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "generateNFT",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "underlyingAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "underlyingSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "address",
+            "name": "exerciseAsset",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "exerciseSymbol",
+            "type": "string"
+          },
+          {
+            "internalType": "uint40",
+            "name": "exerciseTimestamp",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint40",
+            "name": "expiryTimestamp",
+            "type": "uint40"
+          },
+          {
+            "internalType": "uint96",
+            "name": "underlyingAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "uint96",
+            "name": "exerciseAmount",
+            "type": "uint96"
+          },
+          {
+            "internalType": "enum IOptionSettlementEngine.TokenType",
+            "name": "tokenType",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ITokenURIGenerator.TokenURIParams",
+        "name": "params",
+        "type": "tuple"
+      }
+    ],
+    "name": "generateName",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "pure",
+    "type": "function"
+  }
+]

--- a/networks.json
+++ b/networks.json
@@ -1,7 +1,10 @@
 {
   "goerli": {
     "OptionsSettlementEngine": {
-      "address": "0x8F4F0e14dBe9F53A54B9D8B7C18Ad5BB647b683d"
+      "address": "0x31274a640ffDE3e3fAD51eFA083DBb3f6b875ea6"
+    },
+    "TokenURIGenerator": {
+      "address": "0x3595424AF748E0bc1D7f1AeE5ed200E8C2AE3b73"
     }
   }
 }

--- a/networks.json
+++ b/networks.json
@@ -1,10 +1,10 @@
 {
   "goerli": {
     "OptionsSettlementEngine": {
-      "address": "0x31274a640ffDE3e3fAD51eFA083DBb3f6b875ea6"
+      "address": "0x77ba40dEad8ED6def739563fE4293A0035F296C9"
     },
     "TokenURIGenerator": {
-      "address": "0x3595424AF748E0bc1D7f1AeE5ed200E8C2AE3b73"
+      "address": "0x3cB46472fc17440fD76D7acE9df6598de11Af0AE"
     }
   }
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -155,3 +155,11 @@ type TokenDayData @entity {
   # token volume in usd
   volumeUSD: BigDecimal!
 }
+
+type FeeSwitch @entity {
+  # OptionSettlementEngine contract address
+  id: ID!
+  # recipient of fees
+  feeToAddress: String!
+  isEnabled: Boolean!
+}

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -19,6 +19,8 @@ import {
   TransferBatch as TransferBatchEvent,
   TransferSingle as TransferSingleEvent,
   URI as URIEvent,
+  FeeToUpdated,
+  FeeSwitchUpdated,
 } from "../generated/OptionSettlementEngine/OptionSettlementEngine";
 import { Option, Claim } from "../generated/schema";
 
@@ -138,7 +140,26 @@ export function handleClaimRedeemed(event: ClaimRedeemed): void {
   dayData.save();
 }
 
+export function handleFeeSwitchUpdated(event: FeeSwitchUpdated): void {
+  let isEnabled = event.params.enabled;
+  let feeTo = event.params.feeTo;
 
+  // create new entity?
+  // let ValoremProtocol = {
+  //   feeToAddress: Address!
+  //   isEnabled: boolean!
+  // }
+}
+
+export function handleFeeToUpdated(event: FeeToUpdated): void {
+  let newFeeTo = event.params.newFeeTo;
+
+  // create new entity?
+  // let ValoremProtocol  = {
+  //   feeToAddress: Address!
+  //   isEnabled: boolean!
+  // }
+}
 
 export function handleFeeAccrued(event: FeeAccrued): void {
   let assetDecimals = BigInt.fromI64(ERC20.bind(event.params.asset).decimals());

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -46,6 +46,7 @@ import { ZERO_ADDRESS } from "./utils/constants";
 import { ERC20 } from "../generated/OptionSettlementEngine/ERC20";
 import {
   initializeToken,
+  loadOrInitializeFeeSwitch,
   loadOrInitializeToken,
   updateTokenDayData,
   updateValoremDayData,
@@ -142,23 +143,20 @@ export function handleClaimRedeemed(event: ClaimRedeemed): void {
 
 export function handleFeeSwitchUpdated(event: FeeSwitchUpdated): void {
   let isEnabled = event.params.enabled;
-  let feeTo = event.params.feeTo;
+  let feeTo = event.params.feeTo.toHexString();
 
-  // create new entity?
-  // let ValoremProtocol = {
-  //   feeToAddress: Address!
-  //   isEnabled: boolean!
-  // }
+  let feeSwitch = loadOrInitializeFeeSwitch(event.address.toHexString());
+  feeSwitch.isEnabled = isEnabled;
+  feeSwitch.feeToAddress = feeTo;
+  feeSwitch.save();
 }
 
 export function handleFeeToUpdated(event: FeeToUpdated): void {
-  let newFeeTo = event.params.newFeeTo;
+  let newFeeTo = event.params.newFeeTo.toHexString();
 
-  // create new entity?
-  // let ValoremProtocol  = {
-  //   feeToAddress: Address!
-  //   isEnabled: boolean!
-  // }
+  let feeSwitch = loadOrInitializeFeeSwitch(event.address.toHexString());
+  feeSwitch.feeToAddress = newFeeTo;
+  feeSwitch.save();
 }
 
 export function handleFeeAccrued(event: FeeAccrued): void {

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -159,12 +159,12 @@ export function handleFeeAccrued(event: FeeAccrued): void {
 }
 
 export function handleFeeSwept(event: FeeSwept): void {
-  let assetDecimals = BigInt.fromI64(ERC20.bind(event.params.token).decimals());
+  let assetDecimals = BigInt.fromI64(ERC20.bind(event.params.asset).decimals());
   let formattedAmount = event.params.amount
     .toBigDecimal()
     .div(exponentToBigDecimal(assetDecimals));
 
-  let assetPrice = getTokenPriceUSD(event.params.token.toHexString());
+  let assetPrice = getTokenPriceUSD(event.params.asset.toHexString());
   let feeValueUSD = assetPrice.times(formattedAmount);
 
   let dayData = updateValoremDayData(event);

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -14,7 +14,7 @@ import {
   ExerciseAssigned,
   FeeAccrued,
   FeeSwept,
-  NewChain,
+  NewOptionType,
   OptionsExercised,
   OptionsWritten,
   TransferBatch as TransferBatchEvent,
@@ -175,7 +175,7 @@ export function handleFeeSwept(event: FeeSwept): void {
   dayData.save();
 }
 
-export function handleNewChain(event: NewChain): void {
+export function handleNewOptionType(event: NewOptionType): void {
   let option = Option.load(event.params.optionId.toString());
 
   if (option == null) {

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -11,7 +11,6 @@ import {
   OptionSettlementEngine,
   ApprovalForAll as ApprovalForAllEvent,
   ClaimRedeemed,
-  ExerciseAssigned,
   FeeAccrued,
   FeeSwept,
   NewOptionType,
@@ -141,7 +140,7 @@ export function handleClaimRedeemed(event: ClaimRedeemed): void {
   dayData.save();
 }
 
-export function handleExerciseAssigned(event: ExerciseAssigned): void {}
+
 
 export function handleFeeAccrued(event: FeeAccrued): void {
   let assetDecimals = BigInt.fromI64(ERC20.bind(event.params.asset).decimals());

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -63,17 +63,15 @@ export function handleClaimRedeemed(event: ClaimRedeemed): void {
   claim.option = event.params.optionId.toString();
   claim.claimed = true;
   claim.claimant = fetchAccount(event.params.redeemer).id;
-  claim.exerciseAsset = fetchAccount(event.params.exerciseAsset).id;
-  claim.underlyingAsset = fetchAccount(event.params.underlyingAsset).id;
-  claim.exerciseAmount = event.params.exerciseAmount;
-  claim.underlyingAmount = event.params.underlyingAmount;
+  claim.exerciseAmount = event.params.exerciseAmountRedeemed;
+  claim.underlyingAmount = event.params.underlyingAmountRedeemed;
 
   claim.save();
 
   // retrieve value of exercise assets being transfered
   let exerciseAssetAddress = claim.exerciseAsset as string;
   let exercisePriceUSD = getTokenPriceUSD(exerciseAssetAddress);
-  let exerciseAmount = event.params.exerciseAmount
+  let exerciseAmount = event.params.exerciseAmountRedeemed
     .toBigDecimal()
     .div(
       exponentToBigDecimal(
@@ -87,7 +85,7 @@ export function handleClaimRedeemed(event: ClaimRedeemed): void {
   // retrieve value of underlying assets being transfered
   let underlyingAssetAddress = claim.underlyingAsset as string;
   let underlyingPriceUSD = getTokenPriceUSD(underlyingAssetAddress);
-  let underlyingAmount = event.params.underlyingAmount
+  let underlyingAmount = event.params.underlyingAmountRedeemed
     .toBigDecimal()
     .div(
       exponentToBigDecimal(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,10 @@
-import { BigDecimal, ethereum } from "@graphprotocol/graph-ts";
-import { ERC1155Contract, ValoremDayData } from "../../generated/schema";
+import { Address, BigDecimal, ethereum } from "@graphprotocol/graph-ts";
+import {
+  ERC1155Contract,
+  FeeSwitch,
+  ValoremDayData,
+} from "../../generated/schema";
+import { OptionSettlementEngine } from "../../generated/OptionSettlementEngine/OptionSettlementEngine";
 
 export * from "./tokens";
 
@@ -31,4 +36,22 @@ export function updateValoremDayData(event: ethereum.Event): ValoremDayData {
   valoremDayData.save();
 
   return valoremDayData;
+}
+
+export function loadOrInitializeFeeSwitch(contractAddress: string): FeeSwitch {
+  let feeSwitch = FeeSwitch.load(contractAddress);
+
+  if (feeSwitch === null) {
+    let optionSettlementEngine = OptionSettlementEngine.bind(
+      Address.fromString(contractAddress)
+    );
+    let initialFeeToAddress = optionSettlementEngine.feeTo().toHexString();
+
+    feeSwitch = new FeeSwitch(contractAddress);
+    feeSwitch.feeToAddress = initialFeeToAddress;
+    feeSwitch.isEnabled = false;
+    feeSwitch.save();
+  }
+
+  return feeSwitch;
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -6,9 +6,9 @@ dataSources:
     name: OptionSettlementEngine
     network: goerli
     source:
-      address: "0x31274a640ffDE3e3fAD51eFA083DBb3f6b875ea6"
+      address: "0x77ba40dEad8ED6def739563fE4293A0035F296C9"
       abi: OptionSettlementEngine
-      startBlock: 8129060
+      startBlock: 8165025
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -45,6 +45,10 @@ dataSources:
           handler: handleFeeAccrued
         - event: FeeSwept(indexed address,indexed address,uint256)
           handler: handleFeeSwept
+        - event: FeeSwitchUpdated(address,bool)
+          handler: handleFeeSwitchUpdated
+        - event: FeeToUpdated(indexed address)
+          handler: handleFeeToUpdated
         - event: NewOptionType(uint256,indexed address,indexed address,uint96,uint96,uint40,indexed uint40)
           handler: handleNewOptionType
         - event: OptionsExercised(indexed uint256,indexed address,uint112)

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -39,19 +39,17 @@ dataSources:
       eventHandlers:
         - event: ApprovalForAll(indexed address,indexed address,bool)
           handler: handleApprovalForAll
-        - event: ClaimRedeemed(indexed uint256,indexed uint256,indexed address,address,address,uint96,uint96)
+        - event: ClaimRedeemed(indexed uint256,indexed uint256,indexed address,uint256,uint256)
           handler: handleClaimRedeemed
-        - event: ExerciseAssigned(indexed uint256,indexed uint256,uint112)
-          handler: handleExerciseAssigned
-        - event: FeeAccrued(indexed address,indexed address,uint256)
+        - event: FeeAccrued(indexed uint256,indexed address,indexed address,uint256)
           handler: handleFeeAccrued
         - event: FeeSwept(indexed address,indexed address,uint256)
           handler: handleFeeSwept
-        - event: NewChain(indexed uint256,indexed address,indexed address,uint96,uint96,uint40,uint40)
-          handler: handleNewChain
+        - event: NewOptionType(uint256,indexed address,indexed address,uint96,uint96,uint40,indexed uint40)
+          handler: handleNewOptionType
         - event: OptionsExercised(indexed uint256,indexed address,uint112)
           handler: handleOptionsExercised
-        - event: OptionsWritten(indexed uint256,indexed address,uint256,uint112)
+        - event: OptionsWritten(indexed uint256,indexed address,indexed uint256,uint112)
           handler: handleOptionsWritten
         - event: TransferBatch(indexed address,indexed address,indexed address,uint256[],uint256[])
           handler: handleTransferBatch

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -6,9 +6,9 @@ dataSources:
     name: OptionSettlementEngine
     network: goerli
     source:
-      address: "0x8F4F0e14dBe9F53A54B9D8B7C18Ad5BB647b683d"
+      address: "0x31274a640ffDE3e3fAD51eFA083DBb3f6b875ea6"
       abi: OptionSettlementEngine
-      startBlock: 7602662
+      startBlock: 8129060
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.5


### PR DESCRIPTION
New contracts were deployed today based on the latest `audit-fixes` branch of core.

This PR updates the ABIs/addresses/mappings so that the subgraph won't fail while indexing the new deployments.

---

There are 2 new events `FeeToUpdated`, and `FeeSwitchUpdated`, that do not have ready-to-merge handlers. 
Do we want to track these on the subgraph? If, not I will clean up mapping.ts and remove the handlers.
If so, I think a new entity for the schema that looks like this would be enough to track it: 
```
type ValoremProtocol/FeeSwitch/etc @entity {
    id: ID!
    feeToAddress: Address!
    isEnabled: boolean!
}
```

---

Since I don't have access to the Subgraph Studio currently, I deployed it temporarily [on the hosted service under my account](https://thegraph.com/hosted-service/subgraph/nickadamson/test-goerli). 
Once it's deployed on the Studio, [#168](https://github.com/valorem-labs-inc/valorem-frontend/issues/168) can be marked as resolved.