### PR TITLE
Review and Update Schema

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -1,13 +1,32 @@
-type Option @entity {
+type OptionType @entity {
+  # OptionId
   id: ID!
-  underlyingAsset: Account
-  exerciseTimestamp: BigInt
-  expiryTimestamp: BigInt
-  exerciseAsset: Account
-  underlyingAmount: BigInt
+
+  # Position
+  underlyingAsset: Token!
+  underlyingAmount: BigInt!
+  exerciseAsset: Token!
+  exerciseAmount: BigInt!
+
+  # Exercisable Window
+  exerciseTimestamp: BigInt!
+  expiryTimestamp: BigInt!
+
+  # The deterministic seed used for fair exercise assignment
   settlementSeed: BigInt
-  exerciseAmount: BigInt
-  creator: Account # address
+
+  # The address that created the newOptionType
+  creator: Account!
+  # The transaction hash for the creation of the newOptionType
+  createTx: String!
+
+  # The amount of ERC-1155 options written for this OptionType
+  amountWritten: BigInt!
+  # The amount of ERC-1155 options exercised for this OptionType
+  amountExercised: BigInt!
+
+  # Claims that belong to this OptionType
+  claims: [Claim!]!
 }
 
 type Claim @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -30,17 +30,32 @@ type OptionType @entity {
 }
 
 type Claim @entity {
+  # ClaimId
   id: ID!
-  option: Option
-  writer: Account
-  amountWritten: BigInt
-  amountExercised: BigInt
-  claimed: Boolean
-  claimant: Account # address
-  exerciseAsset: Account # address
-  underlyingAsset: Account # address
-  exerciseAmount: BigInt
-  underlyingAmount: BigInt
+
+  # The OptionType the Claim belongs to
+  optionType: OptionType!
+
+  # The address that wrote the claim
+  writer: Account!
+  # The  hash of the write transaction
+  writeTx: String!
+
+  # Whether or not claim has been redeemed
+  redeemed: Boolean!
+  # Optional: The address that redeemed the claim
+  redeemer: Account
+  # Optional: The hash of the redeem transaction
+  redeemTx: String
+
+  # The total number of fungible ERC-1155 Options that this claim corresponds to
+  amountWritten: BigInt!
+  # The number of options this claim corresponds to that have been exercised
+  amountExercised: BigInt! # TODO: Depends on contract developments, then track via buckets(?)
+  # Tne amount of the Exercise Asset this claim can redeem post-expiry
+  exercisePositionAmount: BigInt! # TODO: Depends on amountExercised
+  # Tne amount of the Underlying Asset this claim can redeem post-expiry
+  underlyingPositionAmount: BigInt! # TODO: Depends on amountExercised
 }
 
 # https://github.com/OpenZeppelin/openzeppelin-subgraphs

--- a/schema.graphql
+++ b/schema.graphql
@@ -22,7 +22,7 @@ type OptionType @entity {
   # The amount of ERC-1155 options exercised for this OptionType
   amountExercised: BigInt!
 
-  # Claims that belong to this OptionType
+  # Claims which collateralize this type of option
   claims: [Claim!]!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -178,8 +178,8 @@ type DayData @entity {
   notionalVolFeesAccruedUSD: BigDecimal!
   notionalVolFeesSweptUSD: BigDecimal!
 
-  # Clearinghouse pointer
-  clearinghouse: Clearinghouse!
+  # OptionSettlementEngine pointer
+  ose: OptionSettlementEngine!
   # Metrics for each Token on same day
   tokenDayData: [TokenDayData!]! @derivedFrom(field: "dayData")
 }
@@ -193,7 +193,7 @@ type Token @entity {
   name: String!
   decimals: Int!
 
-  # Total number of tokens in Clearinghouse
+  # Total number of tokens in the OSE
   totalValueLocked: BigInt!
 
   # Amount of tokens that are ready to be swept as fees
@@ -214,7 +214,7 @@ type TokenDayData @entity {
   # The Token that these metrics belong to
   token: Token!
 
-  # TVL in Clearinghouse in token units
+  # TVL in OSE in token units
   totalValueLocked: BigInt!
 
   ## Notional Volumes in token units
@@ -241,8 +241,8 @@ type TokenDayData @entity {
   dayData: DayData!
 }
 
-type Clearinghouse @entity {
-  # Clearinghouse contract address
+type OptionSettlementEngine @entity {
+  # OptionSettlementEngine contract address
   id: ID!
 
   # Whether or not fees for protocol are enabled
@@ -251,5 +251,5 @@ type Clearinghouse @entity {
   feeToAddress: Account!
 
   # Daily metrics
-  historicalDayData: [DayData!]! @derivedFrom(field: "clearinghouse")
+  historicalDayData: [DayData!]! @derivedFrom(field: "ose")
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -181,7 +181,9 @@ type ClearinghouseDayData @entity {
   notionalVolFeesAccruedUSD: BigDecimal!
   notionalVolFeesSweptUSD: BigDecimal!
 
-  # Metrics for each token on same day
+  # Clearinghouse pointer
+  clearinghouse: Clearinghouse!
+  # Metrics for each Token on same day
   tokenDayDatas: [TokenDayData!]! @derivedFrom(field: "clearinghouseDayData")
 }
 
@@ -237,6 +239,9 @@ type TokenDayData @entity {
   notionalVolSumUSD: BigDecimal!
   notionalVolFeesAccruedUSD: BigDecimal!
   notionalVolFeesSweptUSD: BigDecimal!
+
+  # Pointer to ClearinghouseDayData for same day
+  clearinghouseDayData: ClearinghouseDayData!
 }
 
 type Clearinghouse @entity {
@@ -248,4 +253,7 @@ type Clearinghouse @entity {
   # The address of the recipient of protocol fees
   feeToAddress: Account!
 
+  # Daily metrics
+  clearinghouseDayDatas: [ClearinghouseDayData!]!
+    @derivedFrom(field: "clearinghouse")
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -162,19 +162,27 @@ type DecimalValue @entity {
   decimals: Int!
 }
 
-type ValoremDayData @entity {
-  # timestamp rounded to current day by dividing by 86400
+type ClearinghouseDayData @entity {
+  # Timestamp of day at 00:00AM UTC
   id: ID!
-  # timestamp rounded to current day by dividing by 86400
+  # Timestamp of day at 00:00AM UTC
   date: Int!
-  # tvl in USD terms
+
+  # TVL in USD
   totalValueLockedUSD: BigDecimal!
-  # volume in USD terms
-  volumeUSD: BigDecimal!
-  # fees accrued in USD terms
-  feesAccrued: BigDecimal!
-  # fees swept in USD terms
-  feesSwept: BigDecimal!
+
+  # Notional Volumes in USD
+  notionalVolWrittenUSD: BigDecimal! # Underlying Asset written
+  notionalVolExercisedUSD: BigDecimal! # Exercise Asset exercised for Options
+  notionalVolRedeemedUSD: BigDecimal! # Underlying and/or Exercise Asset redeemed from Claims
+  notionalVolTransferredUSD: BigDecimal! # Claim Transferred: Current Underlying and/or Exercise Asset; Option Transferred: Underlying Asset
+  notionalVolSettledUSD: BigDecimal! # Fee Earning Volume; Written + Exercised
+  notionalVolSumUSD: BigDecimal! # Written + Exercised + Redeemed + Transferred
+  notionalVolFeesAccruedUSD: BigDecimal!
+  notionalVolFeesSweptUSD: BigDecimal!
+
+  # Metrics for each token on same day
+  tokenDayDatas: [TokenDayData!]! @derivedFrom(field: "clearinghouseDayData")
 }
 
 type Token @entity {
@@ -194,23 +202,41 @@ type Token @entity {
   # Lifetime sum of tokens paid to Valorem as fees
   feesAccrued: BigInt!
 
+  # Daily metrics (tvl, volume, etc) for the token
+  tokenDayDatas: [TokenDayData!]! @derivedFrom(field: "token")
 }
 
 type TokenDayData @entity {
-  # token address concatendated with date
+  # Token Address + Timestamp of day at 00:00AM UTC
   id: ID!
-  # timestamp rounded to current day by dividing by 86400
+  # Timestamp of day at 00:00AM UTC
   date: Int!
-  # pointer to token
+
+  # The Token that these metrics belong to
   token: Token!
-  # tvl across all contracts in token units
-  totalValueLocked: BigDecimal!
-  # tvl across all contracts in usd
-  totalValueLockedUSD: BigDecimal!
-  # token volume in token units
-  volume: BigDecimal!
-  # token volume in usd
-  volumeUSD: BigDecimal!
+
+  # TVL in Clearinghouse in token units
+  totalValueLocked: BigInt!
+
+  ## Notional Volumes in token units
+  notionalVolWritten: BigInt! # Underlying Asset written
+  notionalVolExercised: BigInt! # Exercise Asset exercised for Options
+  notionalVolRedeemed: BigInt! # Underlying and/or Exercise Asset redeemed from Claims
+  notionalVolTransferred: BigInt! # Claim Transferred: Current Underlying and/or Exercise Asset; Option Transferred: Underlying Asset
+  notionalVolSettled: BigInt! # Fee Earning Volume; Written + Exercised
+  notionalVolSum: BigInt! # Written + Exercised + Redeemed + Transferred
+  notionalVolFeesAccrued: BigInt!
+  notionalVolFeesSwept: BigInt!
+
+  ## Notional Volumes in USD
+  notionalVolWrittenUSD: BigDecimal!
+  notionalVolExercisedUSD: BigDecimal!
+  notionalVolRedeemedUSD: BigDecimal!
+  notionalVolTransferredUSD: BigDecimal!
+  notionalVolSettledUSD: BigDecimal!
+  notionalVolSumUSD: BigDecimal!
+  notionalVolFeesAccruedUSD: BigDecimal!
+  notionalVolFeesSweptUSD: BigDecimal!
 }
 
 type FeeSwitch @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -14,8 +14,8 @@ type OptionType @entity {
 
   # The address that created the newOptionType
   creator: Account!
-  # The transaction hash for the creation of the newOptionType
-  createTx: String!
+  # The transaction for the creation of the newOptionType
+  createTx: Transaction!
 
   # The amount of ERC-1155 options written for this OptionType
   amountWritten: BigInt!
@@ -35,15 +35,15 @@ type Claim @entity {
 
   # The address that wrote the claim
   writer: Account!
-  # The  hash of the write transaction
-  writeTx: String!
+  # The write transaction
+  writeTx: Transaction!
 
   # Whether or not claim has been redeemed
   redeemed: Boolean!
   # Optional: The address that redeemed the claim
   redeemer: Account
-  # Optional: The hash of the redeem transaction
-  redeemTx: String
+  # Optional: The redeem transaction
+  redeemTx: Transaction
 
   # The total number of fungible ERC-1155 Options that this claim corresponds to
   amountWritten: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -12,9 +12,6 @@ type OptionType @entity {
   exerciseTimestamp: BigInt!
   expiryTimestamp: BigInt!
 
-  # The deterministic seed used for fair exercise assignment
-  settlementSeed: BigInt
-
   # The address that created the newOptionType
   creator: Account!
   # The transaction hash for the creation of the newOptionType

--- a/schema.graphql
+++ b/schema.graphql
@@ -178,12 +178,17 @@ type ValoremDayData @entity {
 }
 
 type Token @entity {
+  # Token Address
   id: ID!
+
+  # Token Info
   symbol: String!
   name: String!
-  decimals: BigInt!
-  totalValueLocked: BigDecimal!
-  totalValueLockedUSD: BigDecimal!
+  decimals: Int!
+
+  # Total number of tokens in Clearinghouse
+  totalValueLocked: BigInt!
+
 }
 
 type TokenDayData @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -24,6 +24,7 @@ type Claim @entity {
   underlyingAmount: BigInt
 }
 
+# https://github.com/OpenZeppelin/openzeppelin-subgraphs
 type Account @entity {
   id: ID!
   asERC1155: ERC1155Contract
@@ -37,29 +38,36 @@ type Account @entity {
   events: [Event!]! @derivedFrom(field: "emitter")
 }
 
-type ERC1155Contract @entity {
+# https://github.com/OpenZeppelin/openzeppelin-subgraphs
+type ERC1155Contract @entity(immutable: true) {
   id: ID!
   asAccount: Account!
   tokens: [ERC1155Token!]! @derivedFrom(field: "contract")
   balances: [ERC1155Balance!]! @derivedFrom(field: "contract")
   operators: [ERC1155Operator!]! @derivedFrom(field: "contract")
   transfers: [ERC1155Transfer!]! @derivedFrom(field: "contract")
-  totalValueLockedUSD: BigDecimal!
 }
 
+# https://github.com/OpenZeppelin/openzeppelin-subgraphs
 type ERC1155Token @entity {
   id: ID!
-  type: Int
-  option: Option
-  claim: Claim
   contract: ERC1155Contract!
   identifier: BigInt!
   uri: String
   totalSupply: ERC1155Balance!
   balances: [ERC1155Balance!]! @derivedFrom(field: "token")
   transfers: [ERC1155Transfer!]! @derivedFrom(field: "token")
+
+  ## Valorem extended ERC-1155Token attributes
+  # 1 = Option; 2 = Claim
+  type: Int
+  # The OptionId if (type == 1)
+  optionType: OptionType
+  # The ClaimId if (type == 2)
+  claim: Claim
 }
 
+# https://github.com/OpenZeppelin/openzeppelin-subgraphs
 type ERC1155Balance @entity {
   id: ID!
   contract: ERC1155Contract!
@@ -71,6 +79,7 @@ type ERC1155Balance @entity {
   transferToEvent: [ERC1155Transfer!]! @derivedFrom(field: "toBalance")
 }
 
+# https://github.com/OpenZeppelin/openzeppelin-subgraphs
 type ERC1155Operator @entity {
   id: ID!
   contract: ERC1155Contract!
@@ -79,6 +88,7 @@ type ERC1155Operator @entity {
   approved: Boolean!
 }
 
+# https://github.com/OpenZeppelin/openzeppelin-subgraphs
 type ERC1155Transfer implements Event @entity(immutable: true) {
   id: ID!
   emitter: Account!
@@ -95,12 +105,15 @@ type ERC1155Transfer implements Event @entity(immutable: true) {
   valueExact: BigInt!
 }
 
+# https://github.com/OpenZeppelin/openzeppelin-subgraphs
 interface Event {
   id: ID!
   transaction: Transaction!
   emitter: Account!
   timestamp: BigInt!
 }
+
+# https://github.com/OpenZeppelin/openzeppelin-subgraphs
 type Transaction @entity(immutable: true) {
   id: ID!
   timestamp: BigInt!

--- a/schema.graphql
+++ b/schema.graphql
@@ -239,10 +239,13 @@ type TokenDayData @entity {
   notionalVolFeesSweptUSD: BigDecimal!
 }
 
-type FeeSwitch @entity {
-  # OptionSettlementEngine contract address
+type Clearinghouse @entity {
+  # Clearinghouse contract address
   id: ID!
-  # recipient of fees
-  feeToAddress: String!
-  isEnabled: Boolean!
+
+  # Whether or not fees for protocol are enabled
+  feesEnabled: Boolean!
+  # The address of the recipient of protocol fees
+  feeToAddress: Account!
+
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -189,6 +189,11 @@ type Token @entity {
   # Total number of tokens in Clearinghouse
   totalValueLocked: BigInt!
 
+  # Amount of tokens that are ready to be swept as fees
+  feeBalance: BigInt!
+  # Lifetime sum of tokens paid to Valorem as fees
+  feesAccrued: BigInt!
+
 }
 
 type TokenDayData @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -47,12 +47,6 @@ type Claim @entity {
 
   # The total number of fungible ERC-1155 Options that this claim corresponds to
   amountWritten: BigInt!
-  # The number of options this claim corresponds to that have been exercised
-  amountExercised: BigInt! # TODO: Depends on contract developments, then track via buckets(?)
-  # Tne amount of the Exercise Asset this claim can redeem post-expiry
-  exercisePositionAmount: BigInt! # TODO: Depends on amountExercised
-  # Tne amount of the Underlying Asset this claim can redeem post-expiry
-  underlyingPositionAmount: BigInt! # TODO: Depends on amountExercised
 }
 
 # https://github.com/OpenZeppelin/openzeppelin-subgraphs

--- a/schema.graphql
+++ b/schema.graphql
@@ -159,7 +159,7 @@ type DecimalValue @entity {
   decimals: Int!
 }
 
-type ClearinghouseDayData @entity {
+type DayData @entity {
   # Timestamp of day at 00:00AM UTC
   id: ID!
   # Timestamp of day at 00:00AM UTC
@@ -181,7 +181,7 @@ type ClearinghouseDayData @entity {
   # Clearinghouse pointer
   clearinghouse: Clearinghouse!
   # Metrics for each Token on same day
-  tokenDayDatas: [TokenDayData!]! @derivedFrom(field: "clearinghouseDayData")
+  tokenDayData: [TokenDayData!]! @derivedFrom(field: "dayData")
 }
 
 type Token @entity {
@@ -202,7 +202,7 @@ type Token @entity {
   feesAccrued: BigInt!
 
   # Daily metrics (tvl, volume, etc) for the token
-  tokenDayDatas: [TokenDayData!]! @derivedFrom(field: "token")
+  tokenDayData: [TokenDayData!]! @derivedFrom(field: "token")
 }
 
 type TokenDayData @entity {
@@ -237,8 +237,8 @@ type TokenDayData @entity {
   notionalVolFeesAccruedUSD: BigDecimal!
   notionalVolFeesSweptUSD: BigDecimal!
 
-  # Pointer to ClearinghouseDayData for same day
-  clearinghouseDayData: ClearinghouseDayData!
+  # Pointer to DayData for same day
+  dayData: DayData!
 }
 
 type Clearinghouse @entity {
@@ -251,6 +251,5 @@ type Clearinghouse @entity {
   feeToAddress: Account!
 
   # Daily metrics
-  clearinghouseDayDatas: [ClearinghouseDayData!]!
-    @derivedFrom(field: "clearinghouse")
+  historicalDayData: [DayData!]! @derivedFrom(field: "clearinghouse")
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -210,6 +210,8 @@ type TokenDayData @entity {
 
   # TVL in OSE in token units
   totalValueLocked: BigInt!
+  # TVL in OSE in USD
+  totalValueLockedUSD: BigDecimal!
 
   ## Notional Volumes in token units
   notionalVolWritten: BigInt! # Underlying Asset written


### PR DESCRIPTION
This pull request updates the Subgraph's schema with a revised structure that is more closely aligned with how the contracts are structured & how the data will be displayed. 

There are a variety of new notional [(total value controlled by a position)](https://www.investopedia.com/ask/answers/050615/what-difference-between-notional-value-and-market-value.asp) daily metrics being tracked:

  Notional Volume Written:  Value of the Underlying Asset when options are written * the quantity of options written

  Notional Volume Exercised: Value of the Exercise Asset when options are exercised * the quantity of options exercised _*Clarification: This tracks the value of the tokens being transferred FROM a user TO the Option Settlement Engine. The underlying asset that is transferred FROM the Option Settlement Engine TO the user is not included.*_

- Notional Volume Redeemed: Value of both the Underlying and/or Exercise Asset(s) when a claim is redeemed and sent to owner

-  Notional Volume Transferred: 
  **When a Claim Token is being transferred AND it is neither FROM or TO the Option Settlement Engine**, the value of both the Current Underlying and/or Exercise Asset(s) 
  **When an Option is being transferred AND it is neither FROM or TO the Option Settlement Engine**, just the value of the Underlying Asset

- Notional Volume Settled:  This tracks the total _Fee Earning_ Volume; the Notional Volume Written and Notional Volume Exercised added together

- Notional Volume Sum: The Notional Volume Written + Exercised + Redeemed + Transferred

-  Notional Volume of Fees Accrued: The value of fees accrued to the Option Settlement Engine

-  Notional Volume of Fees Swept: The value of fees swept by the Fee Recipient

These metrics are tracked in both token units and $USD for the tokens, and $USD for the entire OptionSettlement Engine.
